### PR TITLE
fix(client): notify and exit when friend disconnects

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,17 @@ func StartClient(server string, port int, name string) {
 
 	defer conn.Close()
 
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			_, err := conn.Read(buf)
+			if err != nil {
+				fmt.Println(Red + "\nYour friend disconnected." + Reset)
+				os.Exit(0)
+			}
+		}
+	}()
+
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		message := scanner.Text()


### PR DESCRIPTION
This PR adds a disconnect notification, so users see when their friend goes offline.
- notify when other person goes offline.
- exit the chat after the other peer lefts.
Fixes #1 
